### PR TITLE
Fix GitHub action workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: elixir:1.9.1-slim
+      image: elixir:1.9.1
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-elixir@v1.0.0
       with:
+        otp-version: 22.2 
         elixir-version: 1.9.4
     - uses: actions/setup-node@v1
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,15 +13,19 @@ jobs:
         ports: ['5432:5432']
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5         
 
-    container:
-      image: elixir:1.9.1
-
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-elixir@v1.0.0
+      with:
+        elixir-version: 1.9.4
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
     - name: Install Dependencies
       run: |
         mix local.rebar --force
         mix local.hex --force
         mix deps.get
+        yarn --cwd assets install
     - name: Run Tests
       run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    
+    services:
+      db:
+        image: postgres:11
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5         
 
     container:
       image: elixir:1.9.1


### PR DESCRIPTION
Fix the existing GitHub action workflow by replacing the container system with just using elixir directly. We need postgres and to compile the bcrypt dep directly. 

Fixes #157 